### PR TITLE
feat/timestring: implement translateInputToHumanReadable function

### DIFF
--- a/src/ezpr/blocks.ts
+++ b/src/ezpr/blocks.ts
@@ -1,11 +1,11 @@
-import { EZPRArguments } from "../types";
+import { EZPRArguments, translateInputToHumanReadable } from "../types";
 
 const ezprMarkdown = (args: EZPRArguments) => `
 ${args.reviewers?.join(" ")} :wave:
 
 *From:* ${args.submitter}
 
-*Estimated Review Time*: ${args.ert}
+*Estimated Review Time*: ${translateInputToHumanReadable(args.ert)}
 
 Please review: ${args.description}
 

--- a/src/types/model.test.ts
+++ b/src/types/model.test.ts
@@ -4,6 +4,7 @@ import {
   EstimatedReviewTimeSchema,
   PRDescriptionSchema,
   PRLinkSchema,
+  translateInputToHumanReadable,
 } from ".";
 
 describe("ChannelSchema Validate", () => {
@@ -173,5 +174,208 @@ describe("PRDescriptionSchema Validate", () => {
     } catch (error) {
       expect(error).toStrictEqual(expectedMaxLengthErr);
     }
+  });
+});
+
+describe("translateInputToHumanReadable", () => {
+
+  test("2h, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2h")).toStrictEqual("2 hours");
+  });
+
+  test("2hs, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2hs")).toStrictEqual("2 hours");
+  });
+
+  test("2hr, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2hr")).toStrictEqual("2 hours");
+  });
+
+  test("2hrs, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2hrs")).toStrictEqual("2 hours");
+  });
+
+  test("2hour, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2hour")).toStrictEqual("2 hours");
+  });
+
+  test("2hours, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2hours")).toStrictEqual("2 hours");
+  });
+
+  test("2 h, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 h")).toStrictEqual("2 hours");
+  });
+
+  test("2 hs, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 hs")).toStrictEqual("2 hours");
+  });
+
+  test("2 hr, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 hr")).toStrictEqual("2 hours");
+  });
+
+  test("2 hrs, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 hrs")).toStrictEqual("2 hours");
+  });
+
+  test("2 hour, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 hour")).toStrictEqual("2 hours");
+  });
+
+  test("2 hours, should return 2 hours", () => {
+    expect(translateInputToHumanReadable("2 hours")).toStrictEqual("2 hours");
+  });
+
+  test("1hours, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1hours")).toStrictEqual("1 hour");
+  });
+
+  test("1h, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1h")).toStrictEqual("1 hour");
+  });
+
+  test("1hs, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1hs")).toStrictEqual("1 hour");
+  });
+
+  test("1hr, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1hr")).toStrictEqual("1 hour");
+  });
+
+  test("1hrs, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1hrs")).toStrictEqual("1 hour");
+  });
+
+  test("1hour, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1hour")).toStrictEqual("1 hour");
+  });
+
+  test("1 hours, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 hours")).toStrictEqual("1 hour");
+  });
+
+  test("1 h, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 h")).toStrictEqual("1 hour");
+  });
+
+  test("1 hs, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 hs")).toStrictEqual("1 hour");
+  });
+
+  test("1 hr, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 hr")).toStrictEqual("1 hour");
+  });
+
+  test("1 hrs, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 hrs")).toStrictEqual("1 hour");
+  });
+  
+  test("1 hour, should return 1 hour", () => {
+    expect(translateInputToHumanReadable("1 hour")).toStrictEqual("1 hour");
+  });
+
+  test("1m, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1m")).toStrictEqual("1 minute");
+  });
+
+  test("1ms, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1ms")).toStrictEqual("1 minute");
+  });
+
+  test("1min, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1min")).toStrictEqual("1 minute");
+  });
+
+  test("1mins, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1mins")).toStrictEqual("1 minute");
+  });
+
+  test("1minute, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1minute")).toStrictEqual("1 minute");
+  });
+
+  test("1minutes, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1minutes")).toStrictEqual("1 minute");
+  });
+
+  test("1 m, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 m")).toStrictEqual("1 minute");
+  });
+
+  test("1 ms, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 ms")).toStrictEqual("1 minute");
+  });
+
+  test("1 min, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 min")).toStrictEqual("1 minute");
+  });
+
+  test("1 mins, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 mins")).toStrictEqual("1 minute");
+  });
+
+  test("1 minute, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 minute")).toStrictEqual("1 minute");
+  });
+
+  test("1 minutes, should return 1 minute", () => {
+    expect(translateInputToHumanReadable("1 minutes")).toStrictEqual(
+      "1 minute"
+    );
+  });
+
+  test("2m, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2m")).toStrictEqual("2 minutes");
+  });
+
+  test("2ms, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2ms")).toStrictEqual("2 minutes");
+  });
+
+  test("2min, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2min")).toStrictEqual("2 minutes");
+  });
+
+  test("2mins, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2mins")).toStrictEqual("2 minutes");
+  });
+
+  test("2minute, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2minute")).toStrictEqual("2 minutes");
+  });
+
+  test("2minutes, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2minutes")).toStrictEqual(
+      "2 minutes"
+    );
+  });
+
+  test("2 m, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 m")).toStrictEqual("2 minutes");
+  });
+
+  test("2 ms, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 ms")).toStrictEqual("2 minutes");
+  });
+
+  test("2 min, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 min")).toStrictEqual("2 minutes");
+  });
+
+  test("2 mins, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 mins")).toStrictEqual("2 minutes");
+  });
+
+  test("2 minute, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 minute")).toStrictEqual(
+      "2 minutes"
+    );
+  });
+  
+  test("2 minutes, should return 2 minutes", () => {
+    expect(translateInputToHumanReadable("2 minutes")).toStrictEqual(
+      "2 minutes"
+    );
   });
 });

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -42,6 +42,28 @@ export const PRLinkSchema = z.string().trim().url();
 
 export declare type EstimatedReviewTime = string;
 
+export function translateInputToHumanReadable(s: string): string {
+  var output = "";
+  var i = 0;
+
+  while (i < s.length && s.charAt(i) !== "h" && s.charAt(i) !== "m") {
+    if (s.charAt(i) !== " ") {
+      output += s.charAt(i);
+    }
+    i++;
+  }
+  const isPlural = parseInt(output.trim()) > 1;
+
+  if (s.charAt(i) === "h") {
+    output += " hour";
+  } else {
+    output += " minute";
+  }
+  if (isPlural) {
+    output += "s";
+  }
+  return output;
+}
 const ertRegex = new RegExp(/^(\d){1,2}( )?(hour|minute|min|hr|m|h)(s)?$/);
 
 export const EstimatedReviewTimeSchema = z.string().trim().regex(ertRegex, {


### PR DESCRIPTION
## [EZPR-002] feat/timestring: implement translateInputToHumanReadable function

<!--- Please add in the issue number this PR is fixing below. If an issue does not exist, create one! --->

Fixes: #2 

- [x] Has the code been formatted? Make sure you run `npx prettier --write .`
- [ ] Have dependencies/packages been added?

### Changes

Function utilizes an output variable which iterates over a string to contain all non-space numerical values until the function reaches the characters "h" or "m" then concatenates " hour(s)" or " minute(s)" respectively depending on whether it warrants plurality.