### PR TITLE
feat/view-pr-button: add view button block to message & add pr link validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@
 Fixes: #
 
 - [ ] How has the code been tested?
-    - [ ] Smoke tests (Please provide recordings/screenshots)
-    - [ ] Unit tests
+  - [ ] Smoke tests (Please provide recordings/screenshots)
+  - [ ] Unit tests
 - [ ] Has the code been formatted? Make sure you run `npx prettier --write .`
 - [ ] Have dependencies/packages been added?
 

--- a/src/ezpr/blocks.ts
+++ b/src/ezpr/blocks.ts
@@ -20,4 +20,18 @@ export const ezprMessage = (args: EZPRArguments) => [
       text: ezprMarkdown(args),
     },
   },
+  {
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        text: {
+          type: "plain_text",
+          text: "View",
+        },
+        style: "primary",
+        url: `${args.link}`,
+      },
+    ],
+  },
 ];

--- a/src/ezpr/blocks.ts
+++ b/src/ezpr/blocks.ts
@@ -9,7 +9,7 @@ ${args.reviewers?.join(" ")} :wave:
 
 Please review: ${args.description}
 
-PR Link: ${args.link}
+PR Link: ${args.pullRequest.link}
 `;
 
 export const ezprMessage = (args: EZPRArguments) => [
@@ -30,7 +30,7 @@ export const ezprMessage = (args: EZPRArguments) => [
           text: "View",
         },
         style: "primary",
-        url: `${args.link}`,
+        url: `${args.pullRequest.link}`,
       },
     ],
   },

--- a/src/types/ezpr.ts
+++ b/src/types/ezpr.ts
@@ -8,6 +8,7 @@ import {
   MentionsSchema,
   PRDescriptionSchema,
   PRLinkSchema,
+  PullRequest,
 } from "./model";
 
 const EZPRArgumentsSchema = z.object({
@@ -23,7 +24,7 @@ const EZPRArgumentsSchema = z.object({
 
 export class EZPRArguments {
   submitter: Mention;
-  link: string;
+  pullRequest: PullRequest;
   ert: string;
   description: string;
   channel?: string;
@@ -52,10 +53,10 @@ export class EZPRArguments {
       input,
     };
 
-    EZPRArgumentsSchema.parse(args);
-
+    // eslint-disable-next-line no-console
+    const pr = EZPRArgumentsSchema.parse(args) as unknown as PullRequest;
     this.submitter = submitter;
-    this.link = link;
+    this.pullRequest = pr;
     this.ert = ert;
     this.description = description;
     this.channel = channel;

--- a/src/types/index.test.ts
+++ b/src/types/index.test.ts
@@ -19,7 +19,7 @@ describe("EZPRArguments", () => {
     expect(
       new EZPRArguments(
         "@jane.doe",
-        "http://github.com",
+        "http://github.com/jcserv/ez-pr-bot/pulls/1",
         "15m",
         "description",
         "#test",

--- a/src/types/model.test.ts
+++ b/src/types/model.test.ts
@@ -114,7 +114,31 @@ describe("PRLinkSchema Validate", () => {
     expect(PRLinkSchema.parse(input)).toStrictEqual(expected);
   });
 
-  test("valid http github link with extra spaces at front/bacl, should be valid", () => {
+  test("valid http bitbucket link, should be valid", () => {
+    const input = "https://bitbucket.org/my-company/repo/pull-requests/12345";
+    const expected: PullRequest = {
+      website: "bitbucket",
+      org: "my-company",
+      repo: "repo",
+      num: "12345",
+      link: input,
+    };
+    expect(PRLinkSchema.parse(input)).toStrictEqual(expected);
+  });
+
+  test("valid http gitlab link, should be valid", () => {
+    const input = "http://gitlab.com/my-group/my-project/merge_requests/1";
+    const expected: PullRequest = {
+      website: "gitlab",
+      org: "my-group",
+      repo: "my-project",
+      num: "1",
+      link: input,
+    };
+    expect(PRLinkSchema.parse(input)).toStrictEqual(expected);
+  });
+
+  test("valid http github link with extra spaces at front/back, should be valid", () => {
     const expected: PullRequest = {
       website: "github",
       org: "jcserv",

--- a/src/types/model.test.ts
+++ b/src/types/model.test.ts
@@ -6,6 +6,7 @@ import {
   IsUserGroup,
   PRDescriptionSchema,
   PRLinkSchema,
+  PullRequest,
   toMention,
   toMentions,
   translateInputToHumanReadable,
@@ -91,18 +92,39 @@ describe("ChannelSchema Validate", () => {
 describe("PRLinkSchema Validate", () => {
   test("valid https github link, should be valid", () => {
     const input = "https://github.com/jcserv/ez-pr-bot/pulls/1";
-    expect(PRLinkSchema.parse(input)).toStrictEqual(input);
+    const expected: PullRequest = {
+      website: "github",
+      org: "jcserv",
+      repo: "ez-pr-bot",
+      num: "1",
+      link: input,
+    };
+    expect(PRLinkSchema.parse(input)).toStrictEqual(expected);
   });
 
   test("valid http github link, should be valid", () => {
     const input = "http://github.com/jcserv/ez-pr-bot/pulls/1";
-    expect(PRLinkSchema.parse(input)).toStrictEqual(input);
+    const expected: PullRequest = {
+      website: "github",
+      org: "jcserv",
+      repo: "ez-pr-bot",
+      num: "1",
+      link: input,
+    };
+    expect(PRLinkSchema.parse(input)).toStrictEqual(expected);
   });
 
   test("valid http github link with extra spaces at front/bacl, should be valid", () => {
+    const expected: PullRequest = {
+      website: "github",
+      org: "jcserv",
+      repo: "ez-pr-bot",
+      num: "1",
+      link: "http://github.com/jcserv/ez-pr-bot/pulls/1",
+    };
     expect(
       PRLinkSchema.parse("   http://github.com/jcserv/ez-pr-bot/pulls/1  ")
-    ).toStrictEqual("http://github.com/jcserv/ez-pr-bot/pulls/1");
+    ).toStrictEqual(expected);
   });
 
   test("invalid link, should be invalid", () => {
@@ -111,6 +133,12 @@ describe("PRLinkSchema Validate", () => {
         validation: "url",
         code: "invalid_string",
         message: "Invalid url",
+        path: [],
+      },
+      {
+        validation: "regex",
+        code: "invalid_string",
+        message: "Invalid",
         path: [],
       },
     ]);

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -98,7 +98,7 @@ export const GithubURLSchema = z
   .transform((val) => prLinkToPullRequest(val, githubURLRegex));
 
 const gitlabURLRegex =
-  /^http[s]*:\/\/(gitlab).com\/([\w|-]+)\/([\w|-]+)\/merge-requests\/(\d+)$/;
+  /^http[s]*:\/\/(gitlab).com\/([\w|-]+)\/([\w|-]+)\/merge_requests\/(\d+)$/;
 
 export const GitlabURLSchema = z
   .string()

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -45,9 +45,73 @@ export declare type Channel = string;
 // payload.channel_name provides the channel name without the # at front, so we don't validate #'s
 export const ChannelSchema = z.string().trim();
 
+export declare type PullRequest = {
+  website: string;
+  org: string;
+  repo: string;
+  num: string;
+  link: string;
+};
+
+function prLinkToPullRequest(link: string, regex: RegExp): PullRequest {
+  let pullRequest: PullRequest = {
+    website: "",
+    org: "",
+    repo: "",
+    num: "",
+    link: "",
+  };
+  const matches = link.match(regex);
+  if (matches == null || matches.length !== 5) {
+    return pullRequest;
+  }
+  pullRequest = {
+    website: matches[1],
+    org: matches[2],
+    repo: matches[3],
+    num: matches[4],
+    link: matches[0],
+  };
+  return pullRequest;
+}
+
 export declare type PRLink = string;
 
-export const PRLinkSchema = z.string().trim().url();
+const bitbucketURLRegex =
+  /^http[s]*:\/\/(bitbucket).org\/([\w|-]+)\/([\w|-]+)\/pull-requests\/(\d+)$/;
+
+export const BitbucketURLSchema = z
+  .string()
+  .trim()
+  .url()
+  .regex(bitbucketURLRegex)
+  .transform((val) => prLinkToPullRequest(val, bitbucketURLRegex));
+
+const githubURLRegex =
+  /^http[s]*:\/\/(github).com\/([\w|-]+)\/([\w|-]+)\/pulls\/(\d+$)/;
+
+export const GithubURLSchema = z
+  .string()
+  .trim()
+  .url()
+  .regex(githubURLRegex)
+  .transform((val) => prLinkToPullRequest(val, githubURLRegex));
+
+const gitlabURLRegex =
+  /^http[s]*:\/\/(gitlab).com\/([\w|-]+)\/([\w|-]+)\/merge-requests\/(\d+)$/;
+
+export const GitlabURLSchema = z
+  .string()
+  .trim()
+  .url()
+  .regex(gitlabURLRegex)
+  .transform((val) => prLinkToPullRequest(val, gitlabURLRegex));
+
+export const PRLinkSchema = z.union([
+  GithubURLSchema,
+  BitbucketURLSchema,
+  GitlabURLSchema,
+]);
 
 export declare type EstimatedReviewTime = string;
 


### PR DESCRIPTION
## [EZPR-021] feature enhancement: view pr button

<!--- Please add in the issue number this PR is fixing below. If an issue does not exist, create one! --->

Fixes: #21
Fixes: #20 

- [X] How has the code been tested?
    - [X] Smoke tests (Please provide recordings/screenshots)
    - [X] Unit tests
- [X] Has the code been formatted? Make sure you run `npx prettier --write .`
- [ ] Have dependencies/packages been added?

Changes:
- Adds a view button to the PR review request message
- PR Links must adhere to regex for bitbucket, github, and gitlab PR URLs
- PR Link is translated to PullRequest object, for usage in EZPRArguments